### PR TITLE
Fix rich config hook bug

### DIFF
--- a/hooks/go.mod
+++ b/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks v0.8.0
+require github.com/canonical/edgex-snap-hooks v0.9.0
 
 go 1.15

--- a/snap/README.md
+++ b/snap/README.md
@@ -98,3 +98,22 @@ And restart the service:
 **Note** - at this time changes to configuration values in the [Writable] section are not supported.
 
 For details on the mapping of configuration options to Config options, please refer to "Service Environment Configuration Overrides".
+
+## Service Environment Configuration Overrides
+
+**Note** - all of the configuration options below must be specified with the prefix: 'env.'
+
+```
+[Service]
+service.boot-timeout            // Service.BootTimeout
+service.check-interval          // Service.CheckInterval
+service.server-bind-addr        // Service.ServerBindAddr
+service.port                    // Service.Port
+service.startup-msg             // Service.StartupMsg
+service.timeout                 // Service.Timeout
+
+[Clients.CoreData]
+clients.data.port               // Clients.Data.Port
+
+[Clients.Metadata]
+clients.metadata.port           // Clients.Metadata.Port


### PR DESCRIPTION
This commit changes a bug that can occur when
HandleEdgeXConfig is passed a nil extraConf map.
Updating to v0.9.0 of edgex-snap-hooks resolves
the issue.

Signed-off-by: Tony Espy <espy@canonical.com>

