### PR TITLE
fix(snap): move autostart logic to config hook

### DIFF
--- a/hooks/cmd/configure/configure.go
+++ b/hooks/cmd/configure/configure.go
@@ -21,6 +21,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks"
 )
@@ -41,7 +42,7 @@ func main() {
 		debug = true
 	}
 
-	if err = hooks.Init(debug, "device-nmodbus"); err != nil {
+	if err = hooks.Init(debug, "edgex-device-modbus"); err != nil {
 		fmt.Println(fmt.Sprintf("edgex-device-modbus:configure: initialization failure: %v", err))
 		os.Exit(1)
 
@@ -61,5 +62,40 @@ func main() {
 			hooks.Error(fmt.Sprintf("HandleEdgeXConfig failed: %v", err))
 			os.Exit(1)
 		}
+	}
+
+	// If autostart is not explicitly set, default to "no"
+	// as only example service configuration and profiles
+	// are provided by default.
+	autostart, err := cli.Config(hooks.AutostartConfig)
+	if err != nil {
+		hooks.Error(fmt.Sprintf("Reading config 'autostart' failed: %v", err))
+		os.Exit(1)
+	}
+	if autostart == "" {
+		hooks.Debug("edgex-device-modbus autostart is NOT set, initializing to 'no'")
+		autostart = "no"
+	}
+	autostart = strings.ToLower(autostart)
+
+	hooks.Debug(fmt.Sprintf("edgex-device-modbus autostart is %s", autostart))
+
+	// service is stopped/disabled by default in the install hook
+	switch autostart {
+	case "true":
+		fallthrough
+	case "yes":
+		err = cli.Start("device-modbus", true)
+		if err != nil {
+			hooks.Error(fmt.Sprintf("Can't start service - %v", err))
+			os.Exit(1)
+		}
+	case "false":
+	     // no action necessary
+	case "no":
+	     // no action necessary
+	default:
+		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
+		os.Exit(1)
 	}
 }

--- a/hooks/cmd/install/install.go
+++ b/hooks/cmd/install/install.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks"
 )
@@ -49,19 +48,9 @@ func installConfig() error {
 }
 
 func main() {
-	var debug = false
 	var err error
 
-	status, err := cli.Config("debug")
-	if err != nil {
-		fmt.Println(fmt.Sprintf("edgex-device-modbus:install: can't read value of 'debug': %v", err))
-		os.Exit(1)
-	}
-	if status == "true" {
-		debug = true
-	}
-
-	if err = hooks.Init(debug, "edgex-device-modbus"); err != nil {
+	if err = hooks.Init(false, "edgex-device-modbus"); err != nil {
 		fmt.Println(fmt.Sprintf("edgex-device-mqtt::install: initialization failure: %v", err))
 		os.Exit(1)
 
@@ -73,48 +62,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	cli := hooks.NewSnapCtl()
-	svc := fmt.Sprintf("%s.device-mqtt", hooks.SnapInst)
-
-	autostart, err := cli.Config(hooks.AutostartConfig)
+	// disable the service and handle the autostart logic in the configure hook
+	// as default snap configuration is not available when the install hook runs
+	err = cli.Stop("device-modbus", true)
 	if err != nil {
-		hooks.Error(fmt.Sprintf("Reading config 'autostart' failed: %v", err))
+		hooks.Error(fmt.Sprintf("Can't stop service - %v", err))
 		os.Exit(1)
-	}
-
-	// TODO: move profile config before autostart, if profile=default, or
-	// no configuration file exists for the profile, then ignore autostart
-
-	switch strings.ToLower(autostart) {
-	case "true":
-	case "yes":
-		break
-	case "":
-	case "no":
-		// disable app-service-configurable initially because it specific requires configuration
-		// with a device profile that will be specific to each installation
-		err = cli.Stop(svc, true)
-		if err != nil {
-			hooks.Error(fmt.Sprintf("Can't stop service - %v", err))
-			os.Exit(1)
-		}
-	default:
-		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
-		os.Exit(1)
-	}
-
-	envJSON, err := cli.Config(hooks.EnvConfig)
-	if err != nil {
-		hooks.Error(fmt.Sprintf("Reading config 'env' failed: %v", err))
-		os.Exit(1)
-	}
-
-	if envJSON != "" {
-		hooks.Debug(fmt.Sprintf("edgex-device-modbus:install: envJSON: %s", envJSON))
-		err = hooks.HandleEdgeXConfig("device-modbus", envJSON, nil)
-		if err != nil {
-			hooks.Error(fmt.Sprintf("HandleEdgeXConfig failed: %v", err))
-			os.Exit(1)
-		}
 	}
 }


### PR DESCRIPTION
Since snapd doesn't make default snap configuration
from the gadget snap available to the install hook,
this change moves the autostart logic to the config
hook, and also modifies the install hook to always
stop/disable the service.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/master/.github/Contributing.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
